### PR TITLE
New GH syntax for output parameter

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -189,7 +189,7 @@ function start_vm {
     ${preemptible_flag} \
     --labels=gh_ready=0 \
     --metadata=startup-script="$startup_script" \
-    && echo "::set-output name=label::${VM_ID}"
+    && echo "label=${VM_ID}" >> $GITHUB_OUTPUT
 
   safety_off
   while (( i++ < 24 )); do


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/