### PR TITLE
Manually install `at`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,8 @@ inputs:
     description: "Whether the GitHub actions have already been installed at `/actions-runner`."
     default: false
     required: true
+  boot_disk_type:
+    description: "Boot disk type for the GCE instance (https://cloud.google.com/sdk/gcloud/reference/compute/disk-types/list)"
 outputs:
   label:
     description: >-
@@ -103,6 +105,7 @@ runs:
         --image_project=${{ inputs.image_project }}
         --image=${{ inputs.image }}
         --image_family=${{ inputs.image_family }}
+        --boot_disk_type=${{ inputs.boot_disk_type }}
         --preemptible=${{ inputs.preemptible }}
         --ephemeral=${{ inputs.ephemeral }}
         --no_external_address=${{ inputs.no_external_address }}


### PR DESCRIPTION
Newer Ubuntu versions (e.g 22.04) don't offer `at` preinstalled, which is used by the teardown script. We need to install it manually in order not to break on Ubuntu releases.

As #22, this also adds the `boot_disk_type` optional argument.