### PR TITLE
Remove `at` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ See inputs and descriptions [here](./action.yml).
 The GCE runner image should have at least:
  * `gcloud`
  * `git`
- * `at`
  * (optionally) GitHub Actions Runner (see `actions_preinstalled` parameter)
 
 ## Example Workflows


### PR DESCRIPTION
This is a proposal to eliminate `at` as a dependency to bring dodwn the VM at a deferred time (I've kept the default 3 days). This relies on a mix of `nohup` and sleep to avoid launching blocking commands.

I couldn't figure the best way to test it, trying to tear down the machine after a very short wait (0.01 seconds, startup script below) still leads to the workflow jobs getting completed. There's a change I am misunderstanding something.
```sh
  startup_script="
    gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=0 && \\
    RUNNER_ALLOW_RUNASROOT=1 ./config.sh --url https://github.com/${GITHUB_REPOSITORY} --token ${RUNNER_TOKEN} --labels ${VM_ID} --unattended ${ephemeral_flag} --disableupdate && \\
    ./svc.sh install && \\
    ./svc.sh start && \\
    gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1
    # 3 days represents the max workflow runtime. This will shutdown the instance if everything else fails.
    nohup sh -c \"sleep 0.01s && gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &
    "
```

Also, on a completely different note: do we really need the VM to have an external IP address?