### PR TITLE
Use auto shutdown hook instead of explicit shutdown

### DIFF
--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -18,7 +18,7 @@ on:
         description: Service account of the VM, defaults to default compute service account.
         required: false
       shutdown_timeout:
-        description: "Grace period for the `stop` command, in seconds."
+        description: "Shutdown grace period (in seconds)."
         default: 30
         required: true
       no_external_address:
@@ -50,14 +50,10 @@ jobs:
           image_family: ubuntu-2004-lts
           no_external_address: ${{ inputs.no_external_address }}
           actions_preinstalled: ${{ inputs.actions_preinstalled }}
+          shutdown_timeout: ${{ inputs.shutdown_timeout }}
 
   test:
     needs: create-runner
     runs-on: ${{ needs.create-runner.outputs.label }}
     steps:
       - run: echo "This runs on the GCE runner VM"
-      - uses: related-sciences/gce-github-runner@main
-        with:
-          command: stop
-          shutdown_timeout: ${{ inputs.shutdown_timeout }}
-        if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,3 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     steps:
       - run: echo "This runs on the GCE runner VM"
-      - uses: related-sciences/gce-github-runner@main
-        with:
-          command: stop
-        if: always()

--- a/README.md
+++ b/README.md
@@ -28,14 +28,11 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     steps:
       - run: echo "This runs on the GCE VM"
-      - uses: related-sciences/gce-github-runner@v0.7
-        with:
-          command: stop
-        if: always()
 ```
 
  * `create-runner` creates the GCE VM and registers the runner with unique label
- * `test` uses the runner, and destroys it as the last step
+ * `test` uses the runner
+ * the runner VM will be automatically shut down after the workflow via [self-hosted runner hook](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job)
 
 ## Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,6 @@ branding:
   icon: triangle
   color: purple
 inputs:
-  command:
-    description: "`start` or `stop` of the runner"
-    default: start
-    required: true
   token:
     description: >-
       GitHub auth token, needs `repo`/`public_repo` scope: https://docs.github.com/en/rest/reference/actions#self-hosted-runners.
@@ -26,7 +22,7 @@ inputs:
     required: false
   runner_ver:
     description: Version of the GitHub Runner.
-    default: "2.303.0"
+    default: "2.304.0"
     required: true
   machine_zone:
     description: GCE zone
@@ -87,7 +83,7 @@ inputs:
     default: cloud-platform
     required: true
   shutdown_timeout:
-    description: "Grace period for the `stop` command, in seconds."
+    description: "Shutdown grace period (in seconds)."
     default: 30
     required: true
   actions_preinstalled:
@@ -115,7 +111,7 @@ runs:
     - id: gce-github-runner-script
       run: >
         ${{ github.action_path }}/action.sh
-        --command=${{ inputs.command }}
+        --command=start
         --token=${{ inputs.token }}
         --project_id=${{ inputs.project_id }}
         --service_account_key='${{ inputs.service_account_key }}'


### PR DESCRIPTION
Uses https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job to automatically shutdown the runner without the need for an explicit stop command.