### PR TITLE
update runner_ver to 2.308.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
   runner_ver:
     description: Version of the GitHub Runner.
-    default: "2.304.0"
+    default: "2.308.0"
     required: true
   machine_zone:
     description: GCE zone


### PR DESCRIPTION
We noticed an error with the old runner:

>  An error occurred: Runner version v2.304.0 is deprecated and cannot receive messages.
