### PR TITLE
improvement: multiple instance type and multiple zone

### DIFF
--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       machine_zone:
         description: GCE zone
-        default: "europe-west1-b"
+        default: "us-east1-c"
         required: true
       machine_type:
         description: "GCE machine type: https://cloud.google.com/compute/docs/machine-types"
@@ -37,7 +37,7 @@ jobs:
       label: ${{ steps.create-runner.outputs.label }}
     steps:
       - id: create-runner
-        uses: toufreach5/gce-github-runner@multiple-instances
+        uses: related-sciences/gce-github-runner@main
         with:
           token: ${{ secrets.GH_SA_TOKEN }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       machine_zone:
         description: GCE zone
-        default: "us-east1-c"
+        default: "europe-west1-b"
         required: true
       machine_type:
         description: "GCE machine type: https://cloud.google.com/compute/docs/machine-types"
@@ -37,7 +37,7 @@ jobs:
       label: ${{ steps.create-runner.outputs.label }}
     steps:
       - id: create-runner
-        uses: related-sciences/gce-github-runner@main
+        uses: toufreach5/gce-github-runner@multiple-instances
         with:
           token: ${{ secrets.GH_SA_TOKEN }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/action.sh
+++ b/action.sh
@@ -169,6 +169,12 @@ function start_vm {
     gcloud_auth
   fi
 
+  IFS=',' read -r -a machine_type_random <<< "$machine_type"
+  IFS=',' read -r -a zone_random <<< "$machine_zone"
+
+  machine_zone=$(printf "%s\n" "${zone_random[@]}" | shuf -n1)
+  machine_type=$(printf "%s\n" "${machine_type_random[@]}" | shuf -n1)
+ 
   RUNNER_TOKEN=$(curl -S -s -XPOST \
       -H "authorization: Bearer ${token}" \
       https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runners/registration-token |\


### PR DESCRIPTION
This PR add possibility to deploy instance within multiple types.

For exemple:
n1-standard-4, n1-standard-2, n1-standard-8 script will make a random choice.

Add same choices for zone. Obviously, zones need to be in same region.