### PR TITLE
Support gcloud --min-cpu-platform

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -265,7 +265,7 @@ function start_vm {
       $startup_script"
     fi
   fi
-  
+
   # GCE VM label values requirements:
   # - can contain only lowercase letters, numeric characters, underscores, and dashes
   # - have a maximum length of 63 characters
@@ -277,7 +277,7 @@ function start_vm {
   #   - All characters must be either a hyphen (-) or alphanumeric
   # - repository name
   #   - Max length: 100 code points
-  #   - All code points must be either a hyphen (-), an underscore (_), a period (.), 
+  #   - All code points must be either a hyphen (-), an underscore (_), a period (.),
   #     or an ASCII alphanumeric code point
   # ref: https://github.com/dead-claudia/github-limits
   function truncate_to_label {

--- a/action.sh
+++ b/action.sh
@@ -40,6 +40,7 @@ actions_preinstalled=
 maintenance_policy_terminate=
 arm=
 accelerator=
+min_cpu_platform_flag=
 
 OPTLIND=1
 while getopts_long :h opt \
@@ -67,6 +68,7 @@ while getopts_long :h opt \
   arm required_argument \
   maintenance_policy_terminate optional_argument \
   accelerator optional_argument \
+  min_cpu_platform optional_argument \
   help no_argument "" "$@"
 do
   case "$opt" in
@@ -141,7 +143,10 @@ do
       ;;
     accelerator)
       accelerator=$OPTLARG
-      ;;      
+      ;;
+    min_cpu_platform)
+      min_cpu_platform_flag=--min-cpu-platform="$OPTLARG"
+      ;;
     h|help)
       usage
       exit 0
@@ -307,6 +312,7 @@ function start_vm {
     ${subnet_flag} \
     ${accelerator} \
     ${maintenance_policy_flag} \
+    "${min_cpu_platform_flag}" \
     --labels=gh_ready=0,gh_repo_owner="${gh_repo_owner}",gh_repo="${gh_repo}",gh_run_id="${gh_run_id}" \
     --metadata=startup-script="$startup_script" \
     && echo "label=${VM_ID}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -99,6 +99,9 @@ inputs:
   boot_disk_type:
     description: "Boot disk type for the GCE instance (https://cloud.google.com/sdk/gcloud/reference/compute/disk-types/list)"
     required: false
+  min_cpu_platform:
+    description: "When specified, the VM will be scheduled on host with specified CPU architecture or a newer one."
+    required: false
 outputs:
   label:
     description: >-
@@ -135,4 +138,5 @@ runs:
         --actions_preinstalled=${{ inputs.actions_preinstalled }}
         --maintenance_policy_terminate=${{ inputs.maintenance_policy_terminate }}
         --arm=${{ inputs.arm }}
+        --min_cpu_platform="${{ inputs.min_cpu_platform }}"
       shell: bash


### PR DESCRIPTION
References:
- https://cloud.google.com/sdk/gcloud/reference/compute/instances/create#--min-cpu-platform
- https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform

The platform values often contain spaces (e.g. "Intel Haswell") so getting the shell quoting correct was tricky. 