### PR TITLE
Fixup min_cpu_platform handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,8 @@ inputs:
     required: false
   min_cpu_platform:
     description: "When specified, the VM will be scheduled on host with specified CPU architecture or a newer one."
-    required: false
+    default: AUTOMATIC
+    required: true
 outputs:
   label:
     description: >-
@@ -138,5 +139,5 @@ runs:
         --actions_preinstalled=${{ inputs.actions_preinstalled }}
         --maintenance_policy_terminate=${{ inputs.maintenance_policy_terminate }}
         --arm=${{ inputs.arm }}
-        --min_cpu_platform="${{ inputs.min_cpu_platform }}"
+        --min_cpu_platform='${{ inputs.min_cpu_platform }}'
       shell: bash


### PR DESCRIPTION
Fixup https://github.com/related-sciences/gce-github-runner/pull/54

Observed failure:
> ERROR: (gcloud.compute.instances.create) Could not fetch resource:
> \- Invalid value for field 'resource.minCpuPlatform': ''. Invalid CPU platform.

in https://github.com/related-sciences/gce-github-runner/actions/runs/11924197205/job/33234076658