### PR TITLE
Prevent workflows running longer than 5 hours

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -232,8 +232,8 @@ function start_vm {
 	./svc.sh install && \\
 	./svc.sh start && \\
 	gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1
-	# 3 days represents the max workflow runtime. This will shutdown the instance if everything else fails.
-	nohup sh -c \"sleep 3d && gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &
+	# we cancel any workflows longer than 5 hours (was originally 3 days, the max workflow runtime)
+	nohup sh -c \"sleep 5h && gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &
   "
 
   if $actions_preinstalled ; then


### PR DESCRIPTION
There seems to be a bug where cancelling a workflow doesn't take down the runner. In general 3 days is a long time to leave something idle, so let's be a bit more aggressive about shutting them down while we work on fixing the bug