### PR TITLE
Shutdown timeout on error for debugging

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -207,6 +207,7 @@ function start_vm {
   set -e
   shutdown() {
     echo ❌ Machine setup failed so deleting $VM_ID in ${machine_zone} ...
+    sleep ${shutdown_timeout}
     ${shutdown_command}
   }
   trap shutdown ERR

--- a/action.sh
+++ b/action.sh
@@ -206,7 +206,7 @@ function start_vm {
   startup_prelude="#!/bin/bash
   set -e
   shutdown() {
-    echo ❌ Machine setup failed so deleting $VM_ID in ${machine_zone} ...
+    echo ❌ Machine setup failed so deleting $VM_ID in ${machine_zone} in ${shutdown_timeout} seconds ...
     sleep ${shutdown_timeout}
     ${shutdown_command}
   }


### PR DESCRIPTION
Follow up to #60 which makes it a bit easier to debug failures in startup by not immediately deleting the machine.