### PR TITLE
Delete VM when preempted

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -192,7 +192,7 @@ function start_vm {
   image_family_flag=$([[ -z "${image_family}" ]] || echo "--image-family=${image_family}")
   disk_size_flag=$([[ -z "${disk_size}" ]] || echo "--boot-disk-size=${disk_size}")
   boot_disk_type_flag=$([[ -z "${boot_disk_type}" ]] || echo "--boot-disk-type=${boot_disk_type}")
-  preemptible_flag=$([[ "${preemptible}" == "true" ]] && echo "--preemptible" || echo "")
+  preemptible_flag=$([[ "${preemptible}" == "true" ]] && echo "--provisioning-model=SPOT --instance-termination-action=DELETE --max-run-duration=3d" || echo "")
   ephemeral_flag=$([[ "${ephemeral}" == "true" ]] && echo "--ephemeral" || echo "")
   no_external_address_flag=$([[ "${no_external_address}" == "true" ]] && echo "--no-address" || echo "")
   network_flag=$([[ ! -z "${network}"  ]] && echo "--network=${network}" || echo "")


### PR DESCRIPTION
Adds `--instance-termination-action=DELETE` to delete instance when preempted. Without this, when preemptible VM is interrupted it leaves the instance in shutdown state with disk still incurring cost.

To use that flag I also had to switch to spot VM provisioning, which costs the same, have the same functionality and a few more features.

Spot VMs unlike preemptible ones to not have maximum runtime length, so I've picked 3d max runtime as that's already used in the script as "max workflow runtime".